### PR TITLE
db-arch: introduce x86_64 regs(part I)

### DIFF
--- a/crates/db-arch/Cargo.toml
+++ b/crates/db-arch/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
+vm-memory = { version = "0.7", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"
 
 [package.metadata.docs.rs]

--- a/crates/db-arch/src/x86_64/gdt.rs
+++ b/crates/db-arch/src/x86_64/gdt.rs
@@ -1,0 +1,119 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+// For GDT details see arch/x86/include/asm/segment.h
+
+#![allow(missing_docs)]
+
+use kvm_bindings::kvm_segment;
+
+/// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
+#[allow(unused_parens)]
+pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {
+    (((u64::from(base) & 0xff00_0000u64) << (56 - 24))
+        | ((u64::from(flags) & 0x0000_f0ffu64) << 40)
+        | ((u64::from(limit) & 0x000f_0000u64) << (48 - 16))
+        | ((u64::from(base) & 0x00ff_ffffu64) << 16)
+        | (u64::from(limit) & 0x0000_ffffu64))
+}
+
+#[allow(unused_parens)]
+fn get_base(entry: u64) -> u64 {
+    ((((entry) & 0xFF00_0000_0000_0000) >> 32)
+        | (((entry) & 0x0000_00FF_0000_0000) >> 16)
+        | (((entry) & 0x0000_0000_FFFF_0000) >> 16))
+}
+
+fn get_limit(entry: u64) -> u32 {
+    ((((entry) & 0x000F_0000_0000_0000) >> 32) | ((entry) & 0x0000_0000_0000_FFFF)) as u32
+}
+
+fn get_g(entry: u64) -> u8 {
+    ((entry & 0x0080_0000_0000_0000) >> 55) as u8
+}
+
+fn get_db(entry: u64) -> u8 {
+    ((entry & 0x0040_0000_0000_0000) >> 54) as u8
+}
+
+fn get_l(entry: u64) -> u8 {
+    ((entry & 0x0020_0000_0000_0000) >> 53) as u8
+}
+
+fn get_avl(entry: u64) -> u8 {
+    ((entry & 0x0010_0000_0000_0000) >> 52) as u8
+}
+
+fn get_p(entry: u64) -> u8 {
+    ((entry & 0x0000_8000_0000_0000) >> 47) as u8
+}
+
+fn get_dpl(entry: u64) -> u8 {
+    ((entry & 0x0000_6000_0000_0000) >> 45) as u8
+}
+
+fn get_s(entry: u64) -> u8 {
+    ((entry & 0x0000_1000_0000_0000) >> 44) as u8
+}
+
+fn get_type(entry: u64) -> u8 {
+    ((entry & 0x0000_0F00_0000_0000) >> 40) as u8
+}
+
+/// Automatically build the kvm struct for SET_SREGS from the kernel bit fields.
+///
+/// # Arguments
+///
+/// * `entry` - The gdt entry.
+/// * `table_index` - Index of the entry in the gdt table.
+pub fn kvm_segment_from_gdt(entry: u64, table_index: u8) -> kvm_segment {
+    kvm_segment {
+        base: get_base(entry),
+        limit: get_limit(entry),
+        selector: u16::from(table_index * 8),
+        type_: get_type(entry),
+        present: get_p(entry),
+        dpl: get_dpl(entry),
+        db: get_db(entry),
+        s: get_s(entry),
+        l: get_l(entry),
+        g: get_g(entry),
+        avl: get_avl(entry),
+        padding: 0,
+        unusable: match get_p(entry) {
+            0 => 1,
+            _ => 0,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_parse() {
+        let gdt = gdt_entry(0xA09B, 0x10_0000, 0xfffff);
+        let seg = kvm_segment_from_gdt(gdt, 0);
+        // 0xA09B
+        // 'A'
+        assert_eq!(0x1, seg.g);
+        assert_eq!(0x0, seg.db);
+        assert_eq!(0x1, seg.l);
+        assert_eq!(0x0, seg.avl);
+        // '9'
+        assert_eq!(0x1, seg.present);
+        assert_eq!(0x0, seg.dpl);
+        assert_eq!(0x1, seg.s);
+        // 'B'
+        assert_eq!(0xB, seg.type_);
+        // base and limit
+        assert_eq!(0x10_0000, seg.base);
+        assert_eq!(0xfffff, seg.limit);
+        assert_eq!(0x0, seg.unusable);
+    }
+}

--- a/crates/db-arch/src/x86_64/mod.rs
+++ b/crates/db-arch/src/x86_64/mod.rs
@@ -3,7 +3,11 @@
 
 //! CPU architecture specific constants and utilities for the `x86_64` architecture.
 
+/// Definitions for x86 CPUID
 pub mod cpuid;
-
+/// Definitions for x86 Global Descriptor Table
+pub mod gdt;
 /// Definitions for x86 Model Specific Registers(MSR).
 pub mod msr;
+/// Definitions for x86 Registers
+pub mod regs;

--- a/crates/db-arch/src/x86_64/regs.rs
+++ b/crates/db-arch/src/x86_64/regs.rs
@@ -1,0 +1,234 @@
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+#![allow(missing_docs)]
+// x86 reg utility
+
+use std::mem;
+
+use super::gdt::{gdt_entry, kvm_segment_from_gdt};
+
+use kvm_bindings::{kvm_fpu, kvm_sregs};
+use kvm_ioctls::VcpuFd;
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+
+// Initial pagetables.
+pub const PML4_START: u64 = 0x9000;
+pub const PDPTE_START: u64 = 0xa000;
+pub const PDE_START: u64 = 0xb000;
+
+pub const BOOT_GDT_OFFSET: u64 = 0x500;
+pub const BOOT_IDT_OFFSET: u64 = 0x520;
+
+pub const BOOT_GDT_MAX: usize = 4;
+
+pub const EFER_NX: u64 = 0x800;
+pub const EFER_LMA: u64 = 0x400;
+pub const EFER_LME: u64 = 0x100;
+
+pub const X86_CR0_PE: u64 = 0x1;
+pub const X86_CR0_PG: u64 = 0x8000_0000;
+pub const X86_CR4_PAE: u64 = 0x20;
+
+/// Errors thrown while setting up x86_64 registers.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to get SREGs for this CPU.
+    GetStatusRegisters(kvm_ioctls::Error),
+    /// Failed to set base registers for this CPU.
+    SetBaseRegisters(kvm_ioctls::Error),
+    /// Failed to configure the FPU.
+    SetFPURegisters(kvm_ioctls::Error),
+    /// Setting up MSRs failed.
+    SetModelSpecificRegisters(kvm_ioctls::Error),
+    /// Failed to set all MSRs.
+    SetModelSpecificRegistersCount,
+    /// Failed to set SREGs for this CPU.
+    SetStatusRegisters(kvm_ioctls::Error),
+    /// Writing the GDT to RAM failed.
+    WriteGDT,
+    /// Writing the IDT to RAM failed.
+    WriteIDT,
+    /// Writing PDPTE to RAM failed.
+    WritePDPTEAddress,
+    /// Writing PDE to RAM failed.
+    WritePDEAddress,
+    /// Writing PML4 to RAM failed.
+    WritePML4Address,
+}
+type Result<T> = std::result::Result<T, Error>;
+
+/// Configure Floating-Point Unit (FPU) registers for a given CPU.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+pub fn setup_fpu(vcpu: &VcpuFd) -> Result<()> {
+    let fpu: kvm_fpu = kvm_fpu {
+        fcw: 0x37f,
+        mxcsr: 0x1f80,
+        ..Default::default()
+    };
+
+    vcpu.set_fpu(&fpu).map_err(Error::SetFPURegisters)
+}
+
+/// Configures the segment registers and system page tables for a given CPU.
+///
+/// # Arguments
+///
+/// * `mem` - The memory that will be passed to the guest.
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+/// * `pgtable_addr` - Address of the vcpu pgtable.
+pub fn setup_sregs<M: GuestMemory>(
+    mem: &M,
+    vcpu: &VcpuFd,
+    pgtable_addr: Option<GuestAddress>,
+) -> Result<()> {
+    let mut sregs: kvm_sregs = vcpu.get_sregs().map_err(Error::GetStatusRegisters)?;
+
+    configure_segments_and_sregs(mem, &mut sregs)?;
+    setup_page_tables(mem, &mut sregs, pgtable_addr)?; // TODO(dgreid) - Can this be done once per system instead?
+
+    vcpu.set_sregs(&sregs).map_err(Error::SetStatusRegisters)
+}
+
+fn setup_page_tables<M: GuestMemory>(
+    mem: &M,
+    sregs: &mut kvm_sregs,
+    existing_pgtable: Option<GuestAddress>,
+) -> Result<()> {
+    if let Some(pgtable_addr) = existing_pgtable {
+        setup_ap_page_tables(mem, sregs, pgtable_addr)
+    } else {
+        setup_bp_page_tables(mem, sregs)
+    }
+}
+
+fn setup_ap_page_tables<M: GuestMemory>(
+    _mem: &M,
+    sregs: &mut kvm_sregs,
+    pgtable_addr: GuestAddress,
+) -> Result<()> {
+    // Setup page tables with specified pgtable_addr.
+    sregs.cr3 = pgtable_addr.raw_value() as u64;
+    sregs.cr4 |= X86_CR4_PAE;
+    sregs.cr0 |= X86_CR0_PG;
+
+    Ok(())
+}
+
+fn setup_bp_page_tables<M: GuestMemory>(mem: &M, sregs: &mut kvm_sregs) -> Result<()> {
+    // Puts PML4 right after zero page but aligned to 4k.
+    let boot_pml4_addr = GuestAddress(PML4_START);
+    let boot_pdpte_addr = GuestAddress(PDPTE_START);
+    let boot_pde_addr = GuestAddress(PDE_START);
+
+    // Entry covering VA [0..512GB)
+    mem.write_obj(boot_pdpte_addr.raw_value() as u64 | 0x03, boot_pml4_addr)
+        .map_err(|_| Error::WritePML4Address)?;
+
+    // Entry covering VA [0..1GB)
+    mem.write_obj(boot_pde_addr.raw_value() as u64 | 0x03, boot_pdpte_addr)
+        .map_err(|_| Error::WritePDPTEAddress)?;
+    // 512 2MB entries together covering VA [0..1GB). Note we are assuming
+    // CPU supports 2MB pages (/proc/cpuinfo has 'pse'). All modern CPUs do.
+    for i in 0..512 {
+        mem.write_obj((i << 21) + 0x83u64, boot_pde_addr.unchecked_add(i * 8))
+            .map_err(|_| Error::WritePDEAddress)?;
+    }
+
+    sregs.cr3 = boot_pml4_addr.raw_value() as u64;
+    sregs.cr4 |= X86_CR4_PAE;
+    sregs.cr0 |= X86_CR0_PG;
+    Ok(())
+}
+
+fn configure_segments_and_sregs<M: GuestMemory>(mem: &M, sregs: &mut kvm_sregs) -> Result<()> {
+    let gdt_table: [u64; BOOT_GDT_MAX as usize] = [
+        gdt_entry(0, 0, 0),            // NULL
+        gdt_entry(0xa09b, 0, 0xfffff), // CODE
+        gdt_entry(0xc093, 0, 0xfffff), // DATA
+        gdt_entry(0x808b, 0, 0xfffff), // TSS
+    ];
+
+    let code_seg = kvm_segment_from_gdt(gdt_table[1], 1);
+    let data_seg = kvm_segment_from_gdt(gdt_table[2], 2);
+    let tss_seg = kvm_segment_from_gdt(gdt_table[3], 3);
+
+    // Write segments
+    write_gdt_table(&gdt_table[..], mem)?;
+    sregs.gdt.base = BOOT_GDT_OFFSET as u64;
+    sregs.gdt.limit = mem::size_of_val(&gdt_table) as u16 - 1;
+
+    write_idt_value(0, mem)?;
+    sregs.idt.base = BOOT_IDT_OFFSET as u64;
+    sregs.idt.limit = mem::size_of::<u64>() as u16 - 1;
+
+    sregs.cs = code_seg;
+    sregs.ds = data_seg;
+    sregs.es = data_seg;
+    sregs.fs = data_seg;
+    sregs.gs = data_seg;
+    sregs.ss = data_seg;
+    sregs.tr = tss_seg;
+
+    /* 64-bit protected mode */
+    sregs.cr0 |= X86_CR0_PE;
+    sregs.efer |= EFER_LME | EFER_LMA;
+
+    Ok(())
+}
+
+fn write_gdt_table<M: GuestMemory>(table: &[u64], guest_mem: &M) -> Result<()> {
+    let boot_gdt_addr = GuestAddress(BOOT_GDT_OFFSET);
+    for (index, entry) in table.iter().enumerate() {
+        let addr = guest_mem
+            .checked_offset(boot_gdt_addr, index * mem::size_of::<u64>())
+            .ok_or(Error::WriteGDT)?;
+        guest_mem
+            .write_obj(*entry, addr)
+            .map_err(|_| Error::WriteGDT)?;
+    }
+    Ok(())
+}
+
+fn write_idt_value<M: GuestMemory>(val: u64, guest_mem: &M) -> Result<()> {
+    let boot_idt_addr = GuestAddress(BOOT_IDT_OFFSET);
+    guest_mem
+        .write_obj(val, boot_idt_addr)
+        .map_err(|_| Error::WriteIDT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kvm_ioctls::Kvm;
+
+    #[test]
+    fn test_setup_fpu() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        setup_fpu(&vcpu).unwrap();
+
+        let expected_fpu: kvm_fpu = kvm_fpu {
+            fcw: 0x37f,
+            mxcsr: 0x1f80,
+            ..Default::default()
+        };
+        let actual_fpu: kvm_fpu = vcpu.get_fpu().unwrap();
+        // TODO: auto-generate kvm related structures with PartialEq on.
+        assert_eq!(expected_fpu.fcw, actual_fpu.fcw);
+        // Setting the mxcsr register from kvm_fpu inside setup_fpu does not influence anything.
+        // See 'kvm_arch_vcpu_ioctl_set_fpu' from arch/x86/kvm/x86.c.
+        // The mxcsr will stay 0 and the assert below fails. Decide whether or not we should
+        // remove it at all.
+        // assert!(expected_fpu.mxcsr == actual_fpu.mxcsr);
+    }
+}


### PR DESCRIPTION
introduce x86_64 regs to help set regs, sregs and fpu.
This is the first patch of the x86_64 regs, We'll introduce more regs
related functions and unit tests in the coming patches.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>